### PR TITLE
[FIX] Replace `DIP { DUP } ; SWAP` by `DUUP`

### DIFF
--- a/multisig/michelson/minimal_multisig.tz
+++ b/multisig/michelson/minimal_multisig.tz
@@ -19,7 +19,7 @@ code
                   { SWAP ;
                     DIP
                       {
-                        SWAP ; DIIP { DIP { DUP } ; SWAP } ;
+                        SWAP ; DIIP { DUUP } ;
                         # Checks signatures, fails if invalid
                         CHECK_SIGNATURE ; ASSERT ;
                         PUSH nat 1 ; ADD @valid } }

--- a/multisig/michelson/multisig.tz
+++ b/multisig/michelson/multisig.tz
@@ -46,7 +46,7 @@ code
                   { SWAP ;
                     DIP
                       {
-                        SWAP ; DIIP { DIP { DUP } ; SWAP } ;
+                        SWAP ; DIIP { DUUP } ;
                         # Checks signatures, fails if invalid
                         CHECK_SIGNATURE ; ASSERT ;
                         PUSH nat 1 ; ADD @valid } }


### PR DESCRIPTION
This is a work around bug
https://gitlab.com/nomadic-labs/tezos/issues/12, it doesn’t change the
semantics of the contract but is currently required to originate the
contracts.