### PR TITLE
[Multisig] Add a default entry point to recieve tokens and forbid signature lists longer than necessary 

### DIFF
--- a/multisig/michelson/generic.tz
+++ b/multisig/michelson/generic.tz
@@ -1,80 +1,91 @@
-parameter (pair
-             (pair :payload
-                (nat %counter) # counter, used to prevent replay attacks
-                (or :action    # payload to sign, represents the requested action
-                   (lambda %operation unit operation)
-                   (pair %change_keys          # change the keys controlling the multisig
-                      (nat %threshold)         # new threshold
-                      (list %keys key))))     # new list of keys
-             (list %sigs (option signature)));    # signatures
+parameter (or (unit %default)
+              (pair %main
+                 (pair :payload
+                    (nat %counter) # counter, used to prevent replay attacks
+                    (or :action    # payload to sign, represents the requested action
+                       (lambda %operation unit operation)
+                       (pair %change_keys          # change the keys controlling the multisig
+                          (nat %threshold)         # new threshold
+                          (list %keys key))))     # new list of keys
+                 (list %sigs (option signature))));    # signatures
 
 storage (pair (nat %stored_counter) (pair (nat %threshold) (list %keys key))) ;
 
 code
   {
-    UNPAIR ; SWAP ; DUP ; DIP { SWAP } ;
-    DIP
-      {
-        UNPAIR ;
-        # pair the payload with the current contract address, to ensure signatures
-        # can't be replayed accross different contracts if a key is reused.
-        DUP ; SELF ; ADDRESS ; PAIR ;
-        PACK ; # form the binary payload that we expect to be signed
-        DIP { UNPAIR @counter ; DIP { SWAP } } ; SWAP
-      } ;
-
-    # Check that the counters match
-    UNPAIR @stored_counter; DIP { SWAP };
-    ASSERT_CMPEQ ;
-
-    # Compute the number of valid signatures
-    DIP { SWAP } ; UNPAIR @threshold @keys;
-    DIP
-      {
-        # Running count of valid signatures
-        PUSH @valid nat 0; SWAP ;
-        ITER
-          {
-            DIP { SWAP } ; SWAP ;
-            IF_CONS
-              {
-                IF_SOME
-                  { SWAP ;
-                    DIP
-                      {
-                        SWAP ; DIIP { DUUP } ;
-                        # Checks signatures, fails if invalid
-                        { DUUUP; DIP {CHECK_SIGNATURE}; SWAP; IF {DROP} {FAILWITH} };
-                        PUSH nat 1 ; ADD @valid } }
-                  { SWAP ; DROP }
-              }
-              {
-                # There were fewer signatures in the list
-                # than keys. Not all signatures must be present, but
-                # they should be marked as absent using the option type.
-                FAIL
-              } ;
-            SWAP
-          }
-      } ;
-    # Assert that the threshold is less than or equal to the
-    # number of valid signatures.
-    ASSERT_CMPLE ;
-    DROP ; DROP ;
-
-    # Increment counter and place in storage
-    DIP { UNPAIR ; PUSH nat 1 ; ADD @new_counter ; PAIR} ;
-
-    # We have now handled the signature verification part,
-    # produce the operation requested by the signers.
-    NIL operation ; SWAP ;
+    UNPAIR ;
     IF_LEFT
-      { # Get operation
-        UNIT ; EXEC ; CONS
-      }
-      {
-        # Change set of signatures
-        DIP { SWAP ; CAR } ; SWAP ; PAIR ; SWAP
-      };
-    PAIR }
+      { # Default entry point: do nothing
+        # This entry point can be used to send tokens to this contract
+        DROP ; NIL operation ; PAIR }
+      { # Main entry point
+        # Assert no token was sent:
+        # to send tokens, the default entry point should be used
+        PUSH mutez 0 ; AMOUNT ; ASSERT_CMPEQ ;
+        SWAP ; DUP ; DIP { SWAP } ;
+        DIP
+          {
+            UNPAIR ;
+            # pair the payload with the current contract address, to ensure signatures
+            # can't be replayed accross different contracts if a key is reused.
+            DUP ; SELF ; ADDRESS ; PAIR ;
+            PACK ; # form the binary payload that we expect to be signed
+            DIP { UNPAIR @counter ; DIP { SWAP } } ; SWAP
+          } ;
+
+        # Check that the counters match
+        UNPAIR @stored_counter; DIP { SWAP };
+        ASSERT_CMPEQ ;
+
+        # Compute the number of valid signatures
+        DIP { SWAP } ; UNPAIR @threshold @keys;
+        DIP
+          {
+            # Running count of valid signatures
+            PUSH @valid nat 0; SWAP ;
+            ITER
+              {
+                DIP { SWAP } ; SWAP ;
+                IF_CONS
+                  {
+                    IF_SOME
+                      { SWAP ;
+                        DIP
+                          {
+                            SWAP ; DIIP { DUUP } ;
+                            # Checks signatures, fails if invalid
+                            { DUUUP; DIP {CHECK_SIGNATURE}; SWAP; IF {DROP} {FAILWITH} };
+                            PUSH nat 1 ; ADD @valid } }
+                      { SWAP ; DROP }
+                  }
+                  {
+                    # There were fewer signatures in the list
+                    # than keys. Not all signatures must be present, but
+                    # they should be marked as absent using the option type.
+                    FAIL
+                  } ;
+                SWAP
+              }
+          } ;
+        # Assert that the threshold is less than or equal to the
+        # number of valid signatures.
+        ASSERT_CMPLE ;
+        DROP ; DROP ;
+
+        # Increment counter and place in storage
+        DIP { UNPAIR ; PUSH nat 1 ; ADD @new_counter ; PAIR} ;
+
+        # We have now handled the signature verification part,
+        # produce the operation requested by the signers.
+        NIL operation ; SWAP ;
+        IF_LEFT
+          { # Get operation
+            UNIT ; EXEC ; CONS
+          }
+          {
+            # Change set of signatures
+            DIP { SWAP ; CAR } ; SWAP ; PAIR ; SWAP
+          };
+        PAIR }
+  }
 

--- a/multisig/michelson/generic.tz
+++ b/multisig/michelson/generic.tz
@@ -70,7 +70,9 @@ code
         # Assert that the threshold is less than or equal to the
         # number of valid signatures.
         ASSERT_CMPLE ;
-        DROP ; DROP ;
+        # Assert no unchecked signature remains
+        IF_CONS {FAIL} {} ;
+        DROP ;
 
         # Increment counter and place in storage
         DIP { UNPAIR ; PUSH nat 1 ; ADD @new_counter ; PAIR} ;


### PR DESCRIPTION
This contains two slight improvements to the (generic) multisig contract.

The only way to send tokens to a multisig contract after origination was to do it as a side effect of some other operation. In particular, this required the agreement of the signers. The first commit adds a `default` entry point that allows unauthenticated users to send tokens to a multisig contract. The former entry point is called `main` and now also check that no token was sent.

The second commit forbids, in the `main` entry point, signature lists longer than necessary. The main motivation for this change is to simplify the formal specification of the contract.