### PR TITLE
Update errors in multisig contracts

### DIFF
--- a/multisig/michelson/generic.tz
+++ b/multisig/michelson/generic.tz
@@ -21,7 +21,7 @@ code
       { # Main entry point
         # Assert no token was sent:
         # to send tokens, the default entry point should be used
-        PUSH mutez 0 ; AMOUNT ; ASSERT_CMPEQ ;
+        PUSH mutez 0 ; AMOUNT ; IFCMPEQ {} {PUSH string "Non zero transfer"; FAILWITH} ;
         SWAP ; DUP ; DIP { SWAP } ;
         DIP
           {
@@ -35,7 +35,7 @@ code
 
         # Check that the counters match
         UNPAIR @stored_counter; DIP { SWAP };
-        ASSERT_CMPEQ ;
+        IFCMPEQ {} {PUSH string "Counter doesn't match"; FAILWITH} ;
 
         # Compute the number of valid signatures
         DIP { SWAP } ; UNPAIR @threshold @keys;
@@ -54,7 +54,8 @@ code
                           {
                             SWAP ; DIIP { DUUP } ;
                             # Checks signatures, fails if invalid
-                            { DUUUP; DIP {CHECK_SIGNATURE}; SWAP; IF {DROP} {FAILWITH} };
+                            { DUUUP; DIP {CHECK_SIGNATURE}; SWAP;
+                              IF {DROP} {PUSH string "Invalid signature"; PAIR; FAILWITH} };
                             PUSH nat 1 ; ADD @valid } }
                       { SWAP ; DROP }
                   }
@@ -62,16 +63,16 @@ code
                     # There were fewer signatures in the list
                     # than keys. Not all signatures must be present, but
                     # they should be marked as absent using the option type.
-                    FAIL
+                    PUSH string "Fewer signatures than keys"; FAILWITH
                   } ;
                 SWAP
               }
           } ;
         # Assert that the threshold is less than or equal to the
         # number of valid signatures.
-        ASSERT_CMPLE ;
+        IFCMPLE {} {PUSH string "Insufficient signatures"; FAILWITH} ;
         # Assert no unchecked signature remains
-        IF_CONS {FAIL} {} ;
+        IF_CONS {PUSH string "Unchecked signatures left"; FAILWITH} {} ;
         DROP ;
 
         # Increment counter and place in storage

--- a/multisig/michelson/minimal_multisig.tz
+++ b/multisig/michelson/minimal_multisig.tz
@@ -21,7 +21,8 @@ code
                       {
                         SWAP ; DIIP { DUUP } ;
                         # Checks signatures, fails if invalid
-                        CHECK_SIGNATURE ; ASSERT ;
+                        CHECK_SIGNATURE ;
+                        IF {} {PUSH string "Invalid signature"; FAILWITH} ;
                         PUSH nat 1 ; ADD @valid } }
                   { SWAP ; DROP }
               }
@@ -29,15 +30,16 @@ code
                 # There were fewer signatures in the list
                 # than keys. Not all signatures must be present, but
                 # they should be marked as absent using the option type.
-                FAIL
+                PUSH string "Fewer signatures than keys"; FAILWITH
               } ;
             SWAP
           }
       } ;
     # Assert that the threshold is less than or equal to the
     # number of valid signatures.
-    ASSERT_CMPLE ;
-    DROP ; UNPACK (contract unit); ASSERT_SOME ;
+    IFCMPLE {} {PUSH string "Insufficient signatures"; FAILWITH} ;
+    DROP ; UNPACK (contract unit);
+    IF_SOME {} {PUSH string "Failed to unpack dest contract"; FAILWITH};
 
     # We have now handled the signature verification part,
     # produce the operation requested by the signers.

--- a/multisig/michelson/multisig.tz
+++ b/multisig/michelson/multisig.tz
@@ -29,7 +29,7 @@ code
 
     # Check that the counters match
     UNPAIR @stored_counter; DIP { SWAP };
-    ASSERT_CMPEQ ;
+    IFCMPEQ {} {PUSH string "Counter doesn't match"; FAILWITH} ;
 
     # Compute the number of valid signatures
     DIP { SWAP } ; UNPAIR @threshold @keys;
@@ -48,7 +48,8 @@ code
                       {
                         SWAP ; DIIP { DUUP } ;
                         # Checks signatures, fails if invalid
-                        CHECK_SIGNATURE ; ASSERT ;
+                        CHECK_SIGNATURE ;
+                        IF {} {PUSH string "Invalid signature"; FAILWITH} ;
                         PUSH nat 1 ; ADD @valid } }
                   { SWAP ; DROP }
               }
@@ -56,14 +57,14 @@ code
                 # There were fewer signatures in the list
                 # than keys. Not all signatures must be present, but
                 # they should be marked as absent using the option type.
-                FAIL
+                PUSH string "Fewer signatures than keys"; FAILWITH
               } ;
             SWAP
           }
       } ;
     # Assert that the threshold is less than or equal to the
     # number of valid signatures.
-    ASSERT_CMPLE ;
+    IFCMPLE {} {PUSH string "Insufficient signatures"; FAILWITH} ;
     DROP ; DROP ;
 
     # Increment counter and place in storage


### PR DESCRIPTION
Currently, all contracts use `PUSH unit (); FAILWITH` in case of
different failures. It would be more convenient to fail with something
more specific. Here we propose failures with human-readable strings.