### PR TITLE
[multisig] Add the chain id to anti-replay data

### DIFF
--- a/multisig/michelson/generic.tz
+++ b/multisig/michelson/generic.tz
@@ -28,7 +28,7 @@ code
             UNPAIR ;
             # pair the payload with the current contract address, to ensure signatures
             # can't be replayed accross different contracts if a key is reused.
-            DUP ; SELF ; ADDRESS ; PAIR ;
+            DUP ; SELF ; ADDRESS ; CHAIN_ID ; PAIR ; PAIR ;
             PACK ; # form the binary payload that we expect to be signed
             DIP { UNPAIR @counter ; DIP { SWAP } } ; SWAP
           } ;

--- a/multisig/michelson/multisig.tz
+++ b/multisig/michelson/multisig.tz
@@ -22,7 +22,7 @@ code
         UNPAIR ;
         # pair the payload with the current contract address, to ensure signatures
         # can't be replayed accross different contracts if a key is reused.
-        DUP ; SELF ; ADDRESS ; PAIR ;
+        DUP ; SELF ; ADDRESS ; CHAIN_ID ; PAIR ; PAIR ;
         PACK ; # form the binary payload that we expect to be signed
         DIP { UNPAIR @counter ; DIP { SWAP } } ; SWAP
       } ;


### PR DESCRIPTION
This small addition is here to avoid replay between the main chain and
the test chain spawn during phase 3 of the protocol voting procedure.

The contracts are already fixed in both the Tezos CLI client and the
Mi-Cho-Coq framework.