### PR TITLE
[multisig] add root entrypoint to generic multisig

### DIFF
--- a/multisig/michelson/generic.tz
+++ b/multisig/michelson/generic.tz
@@ -1,4 +1,5 @@
-parameter (or (unit %default)
+parameter %root
+          (or (unit %default)
               (pair %main
                  (pair :payload
                     (nat %counter) # counter, used to prevent replay attacks


### PR DESCRIPTION
The `%root` entrypoint is required when the `%default` entrypoint is specified and is not at the root of the parameter.